### PR TITLE
Fixes typing error in certbot config and yml and fixes #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ E.g.
 MY_DOMAIN_NAME=example.com
 EMAIL_ADDRESS=jay@example.com
 ```
-* Now when you want to bring up your server, you will use ```docker-compose -f docker-compose-lets-encrypt.yml up``` which will run the
+* Now when you want to bring up your server, you will use ```docker-compose -f docker-compose-letsencrypt.yml up``` which will run the
 server in the foreground so you can make sure everything gets started alright.
 
-* If everything is running, you may want to CTRL+C, run ```docker-compose -f docker-compose-lets-encrypt.yml down``` to get to a clean slate and then rerun ```docker-compose -f docker-compose-lets-encrypt.yml up -d``` with the added ```-d``` to run the server in the background (in daemon mode)
+* If everything is running, you may want to CTRL+C, run ```docker-compose -f docker-compose-letsencrypt.yml down``` to get to a clean slate and then rerun ```docker-compose -f docker-compose-letsencrypt.yml up -d``` with the added ```-d``` to run the server in the background (in daemon mode)
 
 * Please keep in mind that using the HTTPS method will use the email you specified and the domain name to register the certificate. You can read about the lets encrypt process (using cerbot) over [here](https://certbot.eff.org/lets-encrypt/ubuntuxenial-nginx). The process involves verifying that you are the owner of the domain you have specified and registering you with lets encrypt. 
 

--- a/canarytokens/Dockerfile
+++ b/canarytokens/Dockerfile
@@ -28,6 +28,7 @@ RUN pip install --no-cache-dir PyQRCode==1.2.1
 RUN pip install --no-cache-dir pypng==0.0.18
 RUN pip install --no-cache-dir htmlmin==0.1.10
 RUN pip install --no-cache-dir sendgrid==3.6.5
+RUN pip install --no-cache-dir service_identity
 
 RUN wget -O master.zip https://github.com/thinkst/canarytokens/archive/master.zip?step=7
 RUN unzip master.zip

--- a/docker-compose-letsencrypt.yml
+++ b/docker-compose-letsencrypt.yml
@@ -48,7 +48,7 @@ services:
      - switchboard
     container_name: nginx
     env_file:
-      -certbot.env
+     - certbot.env
 volumes:
   log-volume:
       


### PR DESCRIPTION
Fixes typing errors in README.md (wrong certbot yml name) and in .yml file for certbot (no space in front of certbot.env)