### PR TITLE
Fix README with correct steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ You may follow these steps if you wish to have a public facing canarytokens site
 1) `git clone https://github.com/thinkst/canarytokens-docker.git`
 2) `cd canarytokens-docker/nginx` or if you plan on using HTTPS, `cd canarytokens-docker/certbot-nginx`
 3) `sudo htpasswd -c .htpasswd user` where `user` can be any username you would like to use.
-4) edit the appropriate `nginx.conf` and
+4) `sudo chown <user>:<user> .htpasswd` where `user` is the local linux user
+5) edit the appropriate `nginx.conf` and
 ```
 server {
     ...
@@ -127,10 +128,10 @@ server {
         auth_basic           "Basic Auth Restricted Canrytokens"; <---- ADD
         auth_basic_user_file /etc/nginx/.htpasswd;                 <---- ADD
 ```
-5) edit the appropriate `Dockerfile` and add below `COPY nginx.conf ...`
+6) edit the appropriate `Dockerfile` and add below `COPY nginx.conf ...`
 ```
-COPY htpasswd /etc/nginx/htpasswd
+COPY .htpasswd /etc/nginx/.htpasswd
 ```
-6) rebuild the images using `docker-compose build`, restart your docker containers and enjoy!
+7) rebuild the images using `docker-compose build`, restart your docker containers and enjoy!
 
 Thanks @mamisano for catching a silly issue using the above 🙏 


### PR DESCRIPTION
This patch fixes README.md with correct instructions for modifying Dockerfile under certbot-nginx directory.