### PR TITLE
Added port 6443 for the kubeconfig channel

### DIFF
--- a/canarytokens/requirements.txt
+++ b/canarytokens/requirements.txt
@@ -25,3 +25,4 @@ service_identity
 pyinotify==0.9.6
 pyblake2==1.1.2
 PyNaCl==1.4.0
+PyYAML==5.4.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     - ./uploads:/uploads/
     - log-volume:/logs
     container_name: frontend
-    command: bash -c "rm frontend.pid; twistd -noy frontend.tac --pidfile=frontend.pid"
+    command: bash -c "rm -f frontend.pid; twistd -noy frontend.tac --pidfile=frontend.pid"
   switchboard:
     build: ./canarytokens/
     restart: always
@@ -29,6 +29,7 @@ services:
      - "53:53/udp"
      - "25:25"
      - "3306:3306"
+     - "6443:6443"
      - "51820:51820/udp"
     links:
      - redis
@@ -37,7 +38,7 @@ services:
     volumes_from:
     - frontend
     container_name: switchboard
-    command: bash -c "rm switchboard.pid; twistd -noy switchboard.tac --pidfile=switchboard.pid"
+    command: bash -c "rm -f switchboard.pid; twistd -noy switchboard.tac --pidfile=switchboard.pid"
   nginx:
     restart: always
     image: thinkst/canarytokens_nginx


### PR DESCRIPTION
The Kubeconfig token requires a listener on port 6443 as well as PyYAML for generating the kubeconfigs. Also added the `-f` flag to the `rm` commands to avoid errors from docker-compose when the services are starting up.