### PR TITLE
Fix documentation reference to nonexistant package

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ cd canarytokens-docker
 ```
 * Install Docker compose (if not already present):
 ```
-$ sudo apt-get install python-pip python-dev
+$ sudo apt-get install python3-pip python3-dev
 $ sudo pip install -U docker-compose
 #if this breaks with PyYAML errors, install the libyaml development package
 # sudo apt-get install libyaml-dev


### PR DESCRIPTION
I've recently set up a self-hosted canarytokens instance, and the python packages being referenced in the installation instructions not existing on Ubuntu 20.04 was one of the things I stumbled over. (The other being that setting the CANARY_ALERT_EMAIL... fields is only implicitly mentioned). 

This PR fixes the broken reference by explicitly requesting python3-pip and python3-dev, which exist, install without issue, and result in a functioning canarytokens instance.

To reproduce the issue simply run `sudo apt-get install python-pip python-dev` on any Ubuntu 20.04.