### PR TITLE
Pin Automat to 20.2.0

### DIFF
--- a/canarytokens/requirements.txt
+++ b/canarytokens/requirements.txt
@@ -26,3 +26,4 @@ pyinotify==0.9.6
 pyblake2==1.1.2
 PyNaCl==1.4.0
 PyYAML==5.4.1
+Automat==20.2.0


### PR DESCRIPTION
Specify Automat version to prevent crash on start up. Fixes #121.