### PR TITLE
Tighten location regexs in nginx.confs

### DIFF
--- a/certbot-nginx/nginx.conf
+++ b/certbot-nginx/nginx.conf
@@ -38,7 +38,7 @@ http {
                     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
                     proxy_set_header   X-Forwarded-Host $server_name;
                 }
-                location ~* (/generate|/manage|/download|/history|/settings|/resources|/legal|/.well-known).* {
+                location ~* ^/(generate|manage|download|history|settings|resources/.*|legal)$ {
                     if ($scheme = "http") {
                         return 301 https://$server_name$request_uri;
                     }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -39,7 +39,7 @@ http {
             proxy_set_header   X-Forwarded-Host $server_name;
 
         }
-        location ~* (/generate|/manage|/download|/history|/settings|/resources|/legal|/.well-known).* {
+        location ~* ^/(generate|manage|download|history|settings|resources/.*|legal)$ {
             proxy_pass         http://frontend:8082;
             proxy_redirect     off;
             proxy_set_header   Host $host;


### PR DESCRIPTION
This improves the capability in https://github.com/thinkst/canarytokens/pull/186 allowing users to include the keywords (e.g., generate, manage, history, etc.) in the paths or URI as long as they are not directly in conflict with the frontend elements.