### PR TITLE
T5987: Pin redis to 7.0.10

### DIFF
--- a/docker-compose-letsencrypt.yml
+++ b/docker-compose-letsencrypt.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   redis:
     restart: always
-    image: redis
+    image: redis:7.0.10
     volumes:
     - ./data:/data/
     container_name: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   redis:
     restart: always
-    image: redis
+    image: redis:7.0.10
     volumes:
     - ./data:/data/
     container_name: redis


### PR DESCRIPTION
The docker container for redis `7.0.11` breaks on some infra; this PR pins redis to the previous version.