### PR TITLE
Add persistent HTTP token path blocking to nginx

### DIFF
--- a/certbot-nginx/Dockerfile
+++ b/certbot-nginx/Dockerfile
@@ -9,5 +9,6 @@ RUN apt-get update &&  apt-get install -y \
   python3-certbot-nginx
 
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY conf.d/blocked_tokens.conf /etc/nginx/conf.d/blocked_tokens.conf
 COPY start.sh /
 CMD /start.sh

--- a/certbot-nginx/conf.d/blocked_tokens.conf
+++ b/certbot-nginx/conf.d/blocked_tokens.conf
@@ -1,0 +1,6 @@
+# To block a token:
+		# location ^~ /token_path_prefix_to_block {
+		#      access_log    off;
+		#      log_not_found off;
+		#      return 444;
+		#    }

--- a/certbot-nginx/nginx.conf
+++ b/certbot-nginx/nginx.conf
@@ -21,6 +21,9 @@ http {
                 include       /etc/nginx/mime.types;
                 server_tokens off;
 
+                # Import blocked tokens
+                include /etc/nginx/conf.d/*.conf;
+
                 location ^~ /.well-known/acme-challenge {
                     proxy_pass http://nginx:80;
                     proxy_set_header Host            $host;

--- a/docker-compose-v3-letsencrypt.yml
+++ b/docker-compose-v3-letsencrypt.yml
@@ -58,5 +58,6 @@ services:
      - certbot.env
     volumes:
      - /etc/letsencrypt/:/etc/letsencrypt/
+     - ./nginx/conf.d:/etc/nginx/conf.d/
 volumes:
   log-volume:

--- a/docker-compose-v3.yml
+++ b/docker-compose-v3.yml
@@ -52,6 +52,8 @@ services:
     depends_on:
      - "frontend"
      - "switchboard"
+    volumes:
+     - ./nginx/conf.d:/etc/nginx/conf.d/
     container_name: nginx
     command: /usr/sbin/nginx -c /etc/nginx/nginx.conf -g "daemon off;"
 volumes:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,3 +2,4 @@ FROM nginx
 MAINTAINER Marco Slaviero <marco@thinkst.com>
 LABEL Description="This image provides the http proxy for Canarytokens" Vendor="Thinkst Applied Research" Version="1.3"
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY conf.d/blocked_tokens.conf /etc/nginx/conf.d/blocked_tokens.conf

--- a/nginx/conf.d/blocked_tokens.conf
+++ b/nginx/conf.d/blocked_tokens.conf
@@ -1,0 +1,6 @@
+# To block a token:
+		# location ^~ /token_path_prefix_to_block {
+		#      access_log    off;
+		#      log_not_found off;
+		#      return 444;
+		#    }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -29,6 +29,10 @@ http {
         client_max_body_size 50M;
         listen 80;
         server_name         _;
+
+        # Import blocked tokens
+        include /etc/nginx/conf.d/*.conf;
+
         # Proxying connections to application servers
         location = / {
             proxy_pass         http://frontend:8082/;


### PR DESCRIPTION
## Proposed changes

Previously, tokens have been blocked using IP tables. This PR adds a means to block HTTP-based tokens within the nginx configuration, and maps a file from outside the container to enable that configuration to be persisted.

## Types of changes

What types of changes does your code introduce to this repository?
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
