### PR TITLE
Adding proxy_pass_header to nginx.conf

### DIFF
--- a/certbot-nginx/nginx.conf
+++ b/certbot-nginx/nginx.conf
@@ -67,6 +67,7 @@ http {
                     proxy_set_header   X-Real-IP $remote_addr;
                     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
                     proxy_set_header   X-Forwarded-Host $server_name;
+                    proxy_pass_header Server;
                 }
         }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -66,6 +66,7 @@ http {
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Host $server_name;
+            proxy_pass_header Server;
         }
 
     }


### PR DESCRIPTION
## Proposed changes

In canarytokens/canarytokens/channel_http.py we set the Server header (to Apache), but that is one of the defaultly hidden headers (https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_hide_header). This passes that along to provide better control to the token code.

Currently even though the HTTP response for token hits should have the Server: Apache header set, it responds with Server: nginx.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion