### PR TITLE
Update Ubuntu version from 20.04 to 22.04 for precommit action

### DIFF
--- a/.github/workflows/precommit_tests.yml
+++ b/.github/workflows/precommit_tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   precommit_tests:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v3"


### PR DESCRIPTION
## Proposed changes
Updates our GH action to move away from ubuntu-20.04 which is GH will stop supporting from 15 April.
Successful action run here: https://github.com/thinkst/canarytokens-docker/actions/runs/14401202034